### PR TITLE
Add nuget.config with sitecore source

### DIFF
--- a/code/NuGet.Config
+++ b/code/NuGet.Config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+    <packageSources>
+        <add key="sc-packages" value="https://sitecore.myget.org/F/sc-packages/api/v3/index.json" />
+    </packageSources>
+</configuration>


### PR DESCRIPTION
This allows to not configure sources in studio. Just clone and restore :)
Fix for #3
