### PR TITLE
Add Site Info Properties builder

### DIFF
--- a/code/Sitecore.NSubstitute.UnitTests/SiteInfoPropertiesBuilderTester.cs
+++ b/code/Sitecore.NSubstitute.UnitTests/SiteInfoPropertiesBuilderTester.cs
@@ -1,4 +1,5 @@
-﻿using FluentAssertions;
+﻿using System;
+using FluentAssertions;
 using Sitecore.Data;
 using Sitecore.NSubstituteUtils;
 using Xunit;
@@ -11,6 +12,40 @@ namespace Sitecore.NSubstitute.UnitTests
         public void EmptySiteInfoProperties_CanBeCreated()
         {
             new SiteInfoPropertiesBuilder().ToSitecoreSiteInfoProperties().Should().NotBeNull();
+        }
+
+        [Fact]
+        public void EmptySiteInfoProperties_CanBeCreatedWithSpecifiedName()
+        {
+            string siteName = Guid.NewGuid().ToString();
+            var properties = new SiteInfoPropertiesBuilder(siteName).ToSitecoreSiteInfoProperties();
+
+            properties[NSubstituteUtils.Constants.SiteProperties.SiteName].Should().Be(siteName);
+        }
+
+        [Fact]
+        public void ToSitecoreSiteInfoProperties_ReturnsCopyWhenAsked()
+        {
+            string siteName = Guid.NewGuid().ToString();
+            string newSiteName = Guid.NewGuid().ToString();
+            var builder = new SiteInfoPropertiesBuilder(siteName);
+            var properties = builder.ToSitecoreSiteInfoProperties(true);
+            var newProperties = builder.WithSiteName(newSiteName).ToSitecoreSiteInfoProperties();
+
+            properties[NSubstituteUtils.Constants.SiteProperties.SiteName].Should().Be(siteName);
+            newProperties[NSubstituteUtils.Constants.SiteProperties.SiteName].Should().Be(newSiteName);
+        }
+
+        [Fact]
+        public void ToSitecoreSiteInfoProperties_ReturnsInnerCollectionByDefault()
+        {
+            string siteName = Guid.NewGuid().ToString();
+            string newSiteName = Guid.NewGuid().ToString();
+            var builder = new SiteInfoPropertiesBuilder(siteName);
+            var properties = builder.ToSitecoreSiteInfoProperties();
+            builder.WithSiteName(newSiteName);
+
+            properties[NSubstituteUtils.Constants.SiteProperties.SiteName].Should().Be(newSiteName);
         }
 
         [Fact]

--- a/code/Sitecore.NSubstitute.UnitTests/SiteInfoPropertiesBuilderTester.cs
+++ b/code/Sitecore.NSubstitute.UnitTests/SiteInfoPropertiesBuilderTester.cs
@@ -1,0 +1,106 @@
+﻿using FluentAssertions;
+using Sitecore.Data;
+using Sitecore.NSubstituteUtils;
+using Xunit;
+
+namespace Sitecore.NSubstitute.UnitTests
+{
+    public class SiteInfoPropertiesBuilderTester
+    {
+        [Fact]
+        public void EmptySiteInfoProperties_CanBeCreated()
+        {
+            new SiteInfoPropertiesBuilder().ToSitecoreSiteInfoProperties().Should().NotBeNull();
+        }
+
+        [Fact]
+        public void SiteInfoProperties_InitializedCorrectly()
+        {
+            string siteName = new ShortID().ToString();
+            string hostName = new ShortID().ToString();
+            string virtualFolder = new ShortID().ToString();
+            string physicalFolder = new ShortID().ToString();
+            string rootPath = new ShortID().ToString();
+            string siteDefinitionPath = new ShortID().ToString();
+            string startItem = new ShortID().ToString();
+            string database = new ShortID().ToString();
+            string domain = new ShortID().ToString();
+            string language = new ShortID().ToString();
+            string targetHostName = new ShortID().ToString();
+            bool allowDebug = true;
+            bool cacheHtml = true;
+            bool enablePreview = true;
+            bool enableWebEdit = true;
+            bool enableDebugger = true;
+            bool disableClientData = true;
+            bool languageEmbedding = true;
+            string htmlCacheSize = new ShortID().ToString();
+            string registryCacheSize = new ShortID().ToString();
+            string viewStateCacheSize = new ShortID().ToString();
+            string xslCacheSize = new ShortID().ToString();
+            string filteredItemsCacheSize = new ShortID().ToString();
+            bool disableBrowserCaching = true;
+            string loginPage = new ShortID().ToString();
+            string provider = new ShortID().ToString();
+            bool requireLogin = true;
+
+            var properties = new SiteInfoPropertiesBuilder()
+                .WithSiteName(siteName)
+                .WithHostName(hostName)
+                .WithVirtualFolder(virtualFolder)
+                .WithPhysicalFolder(physicalFolder)
+                .WithRootPath(rootPath)
+                .WithSiteDefinitionPath(siteDefinitionPath)
+                .WithStartItem(startItem)
+                .WithDatabase(database)
+                .WithDomain(domain)
+                .WithLanguage(language)
+                .WithTargetHostName(targetHostName)
+                .WithAllowDebug(allowDebug)
+                .WithCacheHtml(cacheHtml)
+                .WithEnablePreview(enablePreview)
+                .WithEnableWebEdit(enableWebEdit)
+                .WithEnableDebugger(enableDebugger)
+                .WithDisableClientData(disableClientData)
+                .WithLanguageEmbedding(languageEmbedding)
+                .WithHtmlCacheSize(htmlCacheSize)
+                .WithRegistryCacheSize(registryCacheSize)
+                .WithViewStateCacheSize(viewStateCacheSize)
+                .WithXslCacheSize(xslCacheSize)
+                .WithFilteredItemsCacheSize(filteredItemsCacheSize)
+                .WithDisableBrowserCaching(disableBrowserCaching)
+                .WithLoginPage(loginPage)
+                .WithProvider(provider)
+                .WithRequireLogin(requireLogin)
+                .ToSitecoreSiteInfoProperties();
+
+            properties[NSubstituteUtils.Constants.SiteProperties.SiteName].Should().Be(siteName);
+            properties[NSubstituteUtils.Constants.SiteProperties.HostName].Should().Be(hostName);
+            properties[NSubstituteUtils.Constants.SiteProperties.VirtualFolder].Should().Be(virtualFolder);
+            properties[NSubstituteUtils.Constants.SiteProperties.PhysicalFolder].Should().Be(physicalFolder);
+            properties[NSubstituteUtils.Constants.SiteProperties.RootPath].Should().Be(rootPath);
+            properties[NSubstituteUtils.Constants.SiteProperties.SiteDefinitionPath].Should().Be(siteDefinitionPath);
+            properties[NSubstituteUtils.Constants.SiteProperties.StartItem].Should().Be(startItem);
+            properties[NSubstituteUtils.Constants.SiteProperties.Database].Should().Be(database);
+            properties[NSubstituteUtils.Constants.SiteProperties.Domain].Should().Be(domain);
+            properties[NSubstituteUtils.Constants.SiteProperties.Language].Should().Be(language);
+            properties[NSubstituteUtils.Constants.SiteProperties.TargetHostName].Should().Be(targetHostName);
+            properties[NSubstituteUtils.Constants.SiteProperties.AllowDebug].Should().Be(allowDebug.ToString().ToLowerInvariant());
+            properties[NSubstituteUtils.Constants.SiteProperties.CacheHtml].Should().Be(cacheHtml.ToString().ToLowerInvariant());
+            properties[NSubstituteUtils.Constants.SiteProperties.EnablePreview].Should().Be(enablePreview.ToString().ToLowerInvariant());
+            properties[NSubstituteUtils.Constants.SiteProperties.EnableWebEdit].Should().Be(enableWebEdit.ToString().ToLowerInvariant());
+            properties[NSubstituteUtils.Constants.SiteProperties.EnableDebugger].Should().Be(enableDebugger.ToString().ToLowerInvariant());
+            properties[NSubstituteUtils.Constants.SiteProperties.DisableClientData].Should().Be(disableClientData.ToString().ToLowerInvariant());
+            properties[NSubstituteUtils.Constants.SiteProperties.LanguageEmbedding].Should().Be(languageEmbedding.ToString().ToLowerInvariant());
+            properties[NSubstituteUtils.Constants.SiteProperties.HtmlCacheSize].Should().Be(htmlCacheSize);
+            properties[NSubstituteUtils.Constants.SiteProperties.RegistryCacheSize].Should().Be(registryCacheSize);
+            properties[NSubstituteUtils.Constants.SiteProperties.ViewStateCacheSize].Should().Be(viewStateCacheSize);
+            properties[NSubstituteUtils.Constants.SiteProperties.XslCacheSize].Should().Be(xslCacheSize);
+            properties[NSubstituteUtils.Constants.SiteProperties.FilteredItemsCacheSize].Should().Be(filteredItemsCacheSize);
+            properties[NSubstituteUtils.Constants.SiteProperties.DisableBrowserCaching].Should().Be(disableBrowserCaching.ToString().ToLowerInvariant());
+            properties[NSubstituteUtils.Constants.SiteProperties.LoginPage].Should().Be(loginPage);
+            properties[NSubstituteUtils.Constants.SiteProperties.Provider].Should().Be(provider);
+            properties[NSubstituteUtils.Constants.SiteProperties.RequireLogin].Should().Be(requireLogin.ToString().ToLowerInvariant());
+        }
+    }
+}

--- a/code/Sitecore.NSubstitute/Constants.cs
+++ b/code/Sitecore.NSubstitute/Constants.cs
@@ -1,0 +1,36 @@
+﻿namespace Sitecore.NSubstituteUtils
+{
+    public struct Constants
+    {
+        public struct SiteProperties
+        {
+            public static readonly string SiteName = "name";
+            public static readonly string HostName = "hostName";
+            public static readonly string VirtualFolder = "virtualFolder";
+            public static readonly string PhysicalFolder = "physicalFolder";
+            public static readonly string RootPath = "rootPath";
+            public static readonly string SiteDefinitionPath = "siteDefinitionPath";
+            public static readonly string StartItem = "startItem";
+            public static readonly string Database = "database";
+            public static readonly string Domain = "domain";
+            public static readonly string Language = "language";
+            public static readonly string TargetHostName = "targetHostName";
+            public static readonly string AllowDebug = "allowDebug";
+            public static readonly string CacheHtml = "cacheHtml";
+            public static readonly string EnablePreview = "enablePreview";
+            public static readonly string EnableWebEdit = "enableWebEdit";
+            public static readonly string EnableDebugger = "enableDebugger";
+            public static readonly string DisableClientData = "disableClientData";
+            public static readonly string LanguageEmbedding = "languageEmbedding";
+            public static readonly string HtmlCacheSize = "htmlCacheSize";
+            public static readonly string RegistryCacheSize = "registryCacheSize";
+            public static readonly string ViewStateCacheSize = "viewStateCacheSize";
+            public static readonly string XslCacheSize = "xslCacheSize";
+            public static readonly string FilteredItemsCacheSize = "filteredItemsCacheSize";
+            public static readonly string DisableBrowserCaching = "disableBrowserCaching";
+            public static readonly string LoginPage = "loginPage";
+            public static readonly string Provider = "provider";
+            public static readonly string RequireLogin = "requireLogin";
+        }
+    }
+}

--- a/code/Sitecore.NSubstitute/Extensions/SiteInfoPropertiesExtensions.cs
+++ b/code/Sitecore.NSubstitute/Extensions/SiteInfoPropertiesExtensions.cs
@@ -1,0 +1,40 @@
+﻿using Sitecore.Collections;
+using Sitecore.Sites;
+using Sitecore.Web;
+
+namespace Sitecore.NSubstituteUtils.Extensions
+{
+    public static class SiteInfoPropertiesExtensions
+    {
+        public static SiteInfo ToSiteInfo(this SiteInfoPropertiesBuilder builder)
+        {
+            if (builder == null)
+            {
+                return null;
+            }
+
+            return new SiteInfo(builder.ToSitecoreSiteInfoProperties());
+        }
+
+        public static Site ToSite(this SiteInfoPropertiesBuilder builder)
+        {
+            if (builder == null)
+            {
+                return null;
+            }
+
+            StringDictionary properties = builder.ToSitecoreSiteInfoProperties();
+            return new Site(properties[Constants.SiteProperties.SiteName], properties);
+        }
+
+        public static SiteContext ToSiteContext(this SiteInfoPropertiesBuilder builder)
+        {
+            if (builder == null)
+            {
+                return null;
+            }
+
+            return new SiteContext(builder.ToSiteInfo());
+        }
+    }
+}

--- a/code/Sitecore.NSubstitute/SiteInfoPropertiesBuilder.cs
+++ b/code/Sitecore.NSubstitute/SiteInfoPropertiesBuilder.cs
@@ -1,14 +1,21 @@
 ﻿using Sitecore.Data;
+using Sitecore.NSubstituteUtils.Extensions;
+using Sitecore.Sites;
+using Sitecore.Web;
 using StringDictionary = Sitecore.Collections.StringDictionary;
 
 namespace Sitecore.NSubstituteUtils
 {
     public class SiteInfoPropertiesBuilder
     {
-        public SiteInfoPropertiesBuilder()
+        public SiteInfoPropertiesBuilder() : this(new ShortID().ToString())
+        {
+        }
+
+        public SiteInfoPropertiesBuilder(string siteName)
         {
             SiteInfoProperties = new StringDictionary();
-            WithSiteName(new ShortID().ToString());
+            WithSiteName(siteName);
         }
 
         protected StringDictionary SiteInfoProperties { get; }
@@ -178,9 +185,20 @@ namespace Sitecore.NSubstituteUtils
             return this;
         }
 
-        public StringDictionary ToSitecoreSiteInfoProperties()
+        public StringDictionary ToSitecoreSiteInfoProperties(bool returnCopy = false)
         {
-            return SiteInfoProperties;
+            if (!returnCopy)
+            {
+                return SiteInfoProperties;
+            }
+
+            return new StringDictionary(SiteInfoProperties.Clone());
         }
+
+        public static implicit operator SiteInfo(SiteInfoPropertiesBuilder builder) => builder.ToSiteInfo();
+
+        public static implicit operator Site(SiteInfoPropertiesBuilder builder) => builder.ToSite();
+
+        public static implicit operator SiteContext(SiteInfoPropertiesBuilder builder) => builder.ToSiteContext();
     }
 }

--- a/code/Sitecore.NSubstitute/SiteInfoPropertiesBuilder.cs
+++ b/code/Sitecore.NSubstitute/SiteInfoPropertiesBuilder.cs
@@ -1,0 +1,186 @@
+﻿using Sitecore.Data;
+using StringDictionary = Sitecore.Collections.StringDictionary;
+
+namespace Sitecore.NSubstituteUtils
+{
+    public class SiteInfoPropertiesBuilder
+    {
+        public SiteInfoPropertiesBuilder()
+        {
+            SiteInfoProperties = new StringDictionary();
+            WithSiteName(new ShortID().ToString());
+        }
+
+        protected StringDictionary SiteInfoProperties { get; }
+
+        public SiteInfoPropertiesBuilder WithSiteName(string siteName)
+        {
+            SiteInfoProperties[Constants.SiteProperties.SiteName] = siteName;
+            return this;
+        }
+
+        public SiteInfoPropertiesBuilder WithHostName(string hostName)
+        {
+            SiteInfoProperties[Constants.SiteProperties.HostName] = hostName;
+            return this;
+        }
+
+        public SiteInfoPropertiesBuilder WithVirtualFolder(string virtualFolder)
+        {
+            SiteInfoProperties[Constants.SiteProperties.VirtualFolder] = virtualFolder;
+            return this;
+        }
+
+        public SiteInfoPropertiesBuilder WithPhysicalFolder(string physicalFolder)
+        {
+            SiteInfoProperties[Constants.SiteProperties.PhysicalFolder] = physicalFolder;
+            return this;
+        }
+
+        public SiteInfoPropertiesBuilder WithRootPath(string rootPath)
+        {
+            SiteInfoProperties[Constants.SiteProperties.RootPath] = rootPath;
+            return this;
+        }
+
+        public SiteInfoPropertiesBuilder WithSiteDefinitionPath(string siteDefinitionPath)
+        {
+            SiteInfoProperties[Constants.SiteProperties.SiteDefinitionPath] = siteDefinitionPath;
+            return this;
+        }
+
+        public SiteInfoPropertiesBuilder WithStartItem(string startItem)
+        {
+            SiteInfoProperties[Constants.SiteProperties.StartItem] = startItem;
+            return this;
+        }
+
+        public SiteInfoPropertiesBuilder WithDatabase(string database)
+        {
+            SiteInfoProperties[Constants.SiteProperties.Database] = database;
+            return this;
+        }
+
+        public SiteInfoPropertiesBuilder WithDomain(string domain)
+        {
+            SiteInfoProperties[Constants.SiteProperties.Domain] = domain;
+            return this;
+        }
+
+        public SiteInfoPropertiesBuilder WithLanguage(string language)
+        {
+            SiteInfoProperties[Constants.SiteProperties.Language] = language;
+            return this;
+        }
+
+        public SiteInfoPropertiesBuilder WithTargetHostName(string targetHostName)
+        {
+            SiteInfoProperties[Constants.SiteProperties.TargetHostName] = targetHostName;
+            return this;
+        }
+
+        public SiteInfoPropertiesBuilder WithAllowDebug(bool allowDebug)
+        {
+            SiteInfoProperties[Constants.SiteProperties.AllowDebug] = allowDebug.ToString().ToLowerInvariant();
+            return this;
+        }
+
+        public SiteInfoPropertiesBuilder WithCacheHtml(bool cacheHtml)
+        {
+            SiteInfoProperties[Constants.SiteProperties.CacheHtml] = cacheHtml.ToString().ToLowerInvariant();
+            return this;
+        }
+
+        public SiteInfoPropertiesBuilder WithEnablePreview(bool enablePreview)
+        {
+            SiteInfoProperties[Constants.SiteProperties.EnablePreview] = enablePreview.ToString().ToLowerInvariant();
+            return this;
+        }
+
+        public SiteInfoPropertiesBuilder WithEnableWebEdit(bool enableWebEdit)
+        {
+            SiteInfoProperties[Constants.SiteProperties.EnableWebEdit] = enableWebEdit.ToString().ToLowerInvariant();
+            return this;
+        }
+
+        public SiteInfoPropertiesBuilder WithEnableDebugger(bool enableDebugger)
+        {
+            SiteInfoProperties[Constants.SiteProperties.EnableDebugger] = enableDebugger.ToString().ToLowerInvariant();
+            return this;
+        }
+
+        public SiteInfoPropertiesBuilder WithDisableClientData(bool disableClientData)
+        {
+            SiteInfoProperties[Constants.SiteProperties.DisableClientData] =
+                disableClientData.ToString().ToLowerInvariant();
+            return this;
+        }
+
+        public SiteInfoPropertiesBuilder WithLanguageEmbedding(bool languageEmbedding)
+        {
+            SiteInfoProperties[Constants.SiteProperties.LanguageEmbedding] =
+                languageEmbedding.ToString().ToLowerInvariant();
+            return this;
+        }
+
+        public SiteInfoPropertiesBuilder WithHtmlCacheSize(string htmlCacheSize)
+        {
+            SiteInfoProperties[Constants.SiteProperties.HtmlCacheSize] = htmlCacheSize;
+            return this;
+        }
+
+        public SiteInfoPropertiesBuilder WithRegistryCacheSize(string registryCacheSize)
+        {
+            SiteInfoProperties[Constants.SiteProperties.RegistryCacheSize] = registryCacheSize;
+            return this;
+        }
+
+        public SiteInfoPropertiesBuilder WithViewStateCacheSize(string viewStateCacheSize)
+        {
+            SiteInfoProperties[Constants.SiteProperties.ViewStateCacheSize] = viewStateCacheSize;
+            return this;
+        }
+
+        public SiteInfoPropertiesBuilder WithXslCacheSize(string xslCacheSize)
+        {
+            SiteInfoProperties[Constants.SiteProperties.XslCacheSize] = xslCacheSize;
+            return this;
+        }
+
+        public SiteInfoPropertiesBuilder WithFilteredItemsCacheSize(string filteredItemsCacheSize)
+        {
+            SiteInfoProperties[Constants.SiteProperties.FilteredItemsCacheSize] = filteredItemsCacheSize;
+            return this;
+        }
+
+        public SiteInfoPropertiesBuilder WithDisableBrowserCaching(bool disableBrowserCaching)
+        {
+            SiteInfoProperties[Constants.SiteProperties.DisableBrowserCaching] =
+                disableBrowserCaching.ToString().ToLowerInvariant();
+            return this;
+        }
+
+        public SiteInfoPropertiesBuilder WithLoginPage(string loginPage)
+        {
+            SiteInfoProperties[Constants.SiteProperties.LoginPage] = loginPage;
+            return this;
+        }
+
+        public SiteInfoPropertiesBuilder WithProvider(string provider)
+        {
+            SiteInfoProperties[Constants.SiteProperties.Provider] = provider;
+            return this;
+        }
+
+        public SiteInfoPropertiesBuilder WithRequireLogin(bool requireLogin)
+        {
+            SiteInfoProperties[Constants.SiteProperties.RequireLogin] = requireLogin.ToString().ToLowerInvariant();
+            return this;
+        }
+
+        public StringDictionary ToSitecoreSiteInfoProperties()
+        {
+            return SiteInfoProperties;
+        }
+    }
+}


### PR DESCRIPTION
Use SiteInfoPropertyBuilder to create SiteInfo properties dictionary.
Use new extension methods to convert builder to SiteInfo, Site and SiteContext