### PR TITLE
Bump NSubstitute version to latest one

### DIFF
--- a/buildscript/component.build
+++ b/buildscript/component.build
@@ -25,7 +25,7 @@
   <target name="compile">
     <property name="compile.configuration" value="Release"/>
     <property name="compile.target" value="Build"/>
-    <property name="compile.msbuild.exe" value="C:\Windows\Microsoft.NET\Framework\v4.0.30319\MSBuild.exe"/>
+    <property name="compile.msbuild.exe" value="C:\Program Files (x86)\Microsoft Visual Studio\2017\Professional\MSBuild\15.0\Bin\MSBuild.exe"/>
     <property name="compile.command.line" value='"${global.paths.code}\Sitecore.NSubstitute.sln" /t:${compile.target} /p:Configuration=${compile.configuration}'/>
     
     <exec program="${compile.msbuild.exe}" commandline="${compile.command.line}"/>

--- a/buildscript/nuspec/SitecoreDI.NSubstiture.nuspec
+++ b/buildscript/nuspec/SitecoreDI.NSubstiture.nuspec
@@ -2,16 +2,17 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>Sitecore.NSubstituteUtils</id>
-    <version>1.0.3</version>
+    <version>2.0.0</version>
     <title>Sitecore.NSubstituteUtils</title>
     <authors>Sergey Marchenko</authors>
     <owners>Sergey Marchenko</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Helper classes to test Sitecote API using NSubstitute.</description>
+    <releaseNotes>Update NSubstitute package dependency to 4.2.1</releaseNotes>
     <tags>Sitecore NSubstitute</tags>
     <dependencies>
       <group targetFramework=".NETFramework4.5.2">
-        <dependency id="NSubstitute" version="1.9.2.0" />
+        <dependency id="NSubstitute" version="4.2.1.0" />
       </group>
     </dependencies>
   </metadata>

--- a/code/Sitecore.NSubstitute.UnitTests/Sitecore.NSubstitute.UnitTests.csproj
+++ b/code/Sitecore.NSubstitute.UnitTests/Sitecore.NSubstitute.UnitTests.csproj
@@ -12,7 +12,6 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NSubstitute" Version="1.9.2" />
     <PackageReference Include="Sitecore.Kernel" Version="8.2.160729" />
   </ItemGroup>
   <ItemGroup>

--- a/code/Sitecore.NSubstitute/Sitecore.NSubstitute.csproj
+++ b/code/Sitecore.NSubstitute/Sitecore.NSubstitute.csproj
@@ -6,7 +6,7 @@
     <RootNamespace>Sitecore.NSubstituteUtils</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="NSubstitute" Version="1.9.2" />
+    <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="Sitecore.Kernel.NoReferences" Version="8.2.160729" />
   </ItemGroup>  
 </Project>


### PR DESCRIPTION
Prev version was released on Oct 23, 2015

https://github.com/nsubstitute/NSubstitute/releases?after=v2.0.2